### PR TITLE
Texture update method that is quite useful with fast refresh rate monitors (e.g 480Hz or more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Features:
 
 - Load textures into OpenGL.
 - Bind and unbind textures for rendering.
+- Update a texture with an equivalent shaped image.
 - Delete textures when no longer needed.
 
 Example:
@@ -269,6 +270,32 @@ texture.bind()
 # Render with the texture
 texture.unbind()
 ```
+
+Another example when speed and memory management is crucial:
+
+```python
+from tachypy import Texture
+import numpy as np
+
+images = np.random.rand(n_insequence, 128, 128, 3)
+
+n_insequence = 200
+blank = np.zeros((H, W, 3), dtype=np.uint8)
+textures = [Texture(blank.copy()) for _ in range(n_in_sequence)]
+```
+In the code above, we pre-initialise a set of 200 textures, perhaps an RSVP or other psychophysics sequence.
+
+```python
+for im, ct in enumerate(images):
+    textures[c].update(im)
+```
+Now whenever we start a new trial, in the waiting time, we can simply update the texture buffer, preventing any GPU leakage that could otherwise happen if we don't perform rigid garbage collection on every loop. The update method prevents our GPU from overload.
+
+```python
+for t in texs_pos + texs_neg + texs_bis:
+    t.delete()
+```
+When the experiment is done, simply delete the textures, and voila.
 
 ## Shapes
 

--- a/README.md
+++ b/README.md
@@ -289,9 +289,9 @@ In the code above, we pre-initialise a set of 200 textures, perhaps an RSVP or o
 
 ```python
 for im, ct in enumerate(images):
-    textures[c].update(im)
+    textures[ct].update(im)
 ```
-Now whenever we start a new trial, in the waiting time, we can simply update the texture buffer, preventing any GPU leakage that could otherwise happen if we don't perform rigid garbage collection on every loop. The update method prevents our GPU from overload.
+Now whenever we start a new trial, in the waiting time, we can simply update the texture buffer with the new set of images for that trial, preventing any GPU leakage that could otherwise happen if we don't perform rigid garbage collection on every trial loop. The update method prevents our GPU from overload. This is especially useful when working with high refresh rate monitors (e.g. 480Hz>)
 
 ```python
 for t in texs_pos + texs_neg + texs_bis:

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ for im, ct in enumerate(images):
 Now whenever we start a new trial, in the waiting time, we can simply update the texture buffer with the new set of images for that trial, preventing any GPU leakage that could otherwise happen if we don't perform rigid garbage collection on every trial loop. The update method prevents our GPU from overload. This is especially useful when working with high refresh rate monitors (e.g. 480Hz>)
 
 ```python
-for t in texs_pos + texs_neg + texs_bis:
+for t in textures:
     t.delete()
 ```
 When the experiment is done, simply delete the textures, and voila.

--- a/README.md
+++ b/README.md
@@ -277,7 +277,9 @@ Another example when speed and memory management is crucial:
 from tachypy import Texture
 import numpy as np
 
-images = np.random.rand(n_insequence, 128, 128, 3)
+H, W = [256]*2 # say we have 256 pixels square images
+
+images = np.random.rand(n_insequence, H, W, 3) # that are also RGB.
 
 n_insequence = 200
 blank = np.zeros((H, W, 3), dtype=np.uint8)

--- a/src/tachypy/textures.py
+++ b/src/tachypy/textures.py
@@ -54,9 +54,40 @@ class Texture:
         glBindTexture(GL_TEXTURE_2D, 0)
         # Reset the modelview matrix to avoid any transformations being carried over
         glLoadIdentity()
+    
+    def update(self, image):
+        """
+        Update pixel data of an existing texture without reallocating GPU object.
+        image: np.ndarray (H, W, 3), uint8
+        """
+        glBindTexture(GL_TEXTURE_2D, self.texture_id)
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
+
+        # If size matches, do sub-image update (fast, no reallocation)
+        w, h = image.shape[1], image.shape[0]
+        glTexSubImage2D(
+            GL_TEXTURE_2D,
+            0,
+            0,
+            0,
+            w,
+            h,
+            GL_RGB,
+            GL_UNSIGNED_BYTE,
+            image
+        )
+        glBindTexture(GL_TEXTURE_2D, 0)
 
     def delete(self):
-        glDeleteTextures([self.texture_id])
+        """
+        Texture deletion from GPU.
+        
+        :param self: Texture instance
+        :return: None
+        """
+        if getattr(self, "texture_id", 0):
+            glDeleteTextures([self.texture_id])
+            self.texture_id = 0
 
     # ---------- Gestion du rect / position ----------
 


### PR DESCRIPTION
added a useful method to our opengl texture that allows recycling existing textures without needing to create new ones, therefore preventing any potential GPU leakage. 