### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system packages for OpenGL/GLFW tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgl1 \
+            libegl1 \
+            libglfw3 \
+            libglu1-mesa \
+            xvfb
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest
+
+      - name: Run tests
+        run: |
+          xvfb-run -a pytest


### PR DESCRIPTION
Adds a minimal GitHub Actions workflow that runs the TachyPy test suite on pushes and pull requests targeting `main`.

Details:
- installs Python 3.12
- installs OpenGL/GLFW runtime packages on Ubuntu
- installs TachyPy in editable mode
- runs `pytest` under `xvfb-run`

Once this workflow has completed successfully, use the required status check named `pytest` or `tests / pytest` in the `main` branch ruleset.