### PR TITLE
Replace TachyPy audio backends with TachyAudio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
 
-    env:
-      TACHYPY_AUDIO_BACKEND: dummy
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ software timestamps alone.
 Install base package:
 
 ```bash
-pip install --pre tachypy
+pip install tachypy
 ```
 
 The base install includes GLFW for display/input, PyOpenGL, Pillow text

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ pip install tachypy
 The base install includes GLFW for display/input, PyOpenGL, Pillow text
 support, pyserial for serial/trigger workflows, and TachyAudio for audio playback.
 Pygame support has been removed; GLFW is the supported display/input backend.
-TachyAudio is currently published as a beta release, so use `--pre` when pip
-needs to resolve it from PyPI.
+TachyAudio is currently published as a beta release; if your pip resolver refuses pre-releases, pass `--pre` (or install `tachyaudio==0.2.0b1`) explicitly.
 
 Editable install for development:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ software timestamps alone.
   - `GLTextSDF` (distance-field text),
   - `GLSystemText` (backward-compatible explicit name for `Text`).
 - Psychophysics helpers (`make_gabor`, gratings, normalization, dithering).
-- Audio playback utility (`Audio`) with backend abstraction (`sounddevice` or `dummy`).
+- Audio playback utility (`Audio`) backed by `tachyaudio`.
 - Test suite for core logic and regressions.
 
 ## Installation
@@ -59,19 +59,21 @@ software timestamps alone.
 Install base package:
 
 ```bash
-pip install tachypy
+pip install --pre tachypy
 ```
 
 The base install includes GLFW for display/input, PyOpenGL, Pillow text
-support, and pyserial for serial/trigger workflows. Pygame support has been
-removed; GLFW is the supported display/input backend.
+support, pyserial for serial/trigger workflows, and TachyAudio for audio playback.
+Pygame support has been removed; GLFW is the supported display/input backend.
+TachyAudio is currently published as a beta release, so use `--pre` when pip
+needs to resolve it from PyPI.
 
 Editable install for development:
 
 ```bash
 git clone https://github.com/Charestlab/tachypy.git
 cd tachypy
-pip install -e .
+pip install --pre -e .
 ```
 
 Optional extras:
@@ -79,41 +81,15 @@ Optional extras:
 ```bash
 pip install -e ".[test]"        # pytest
 pip install -e ".[text]"        # Pillow text fallback
-pip install -e ".[audio_sd]"    # sounddevice backend
+pip install -e ".[audio]"       # TachyAudio audio dependency
 ```
 
-### sounddevice / PortAudio prerequisites
+### Audio dependency
 
-`sounddevice` requires PortAudio on some systems.
-
-Linux (Debian/Ubuntu):
-
-```bash
-sudo apt update
-sudo apt install libportaudio2 libportaudiocpp0 portaudio19-dev
-```
-
-macOS:
-
-Install Homebrew (if needed):
-
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-
-Then install PortAudio:
-
-```bash
-brew install portaudio
-```
-
-Windows:
-
-`sounddevice` wheels often already include what is needed. If installation still fails, one workaround is:
-
-```bash
-choco install portaudio
-```
+TachyPy audio now uses `tachyaudio>=0.2.0b1`. TachyPy no longer depends on
+`sounddevice` or requires users to install PortAudio separately. Hardware/audio
+device validation should still be done on the lab machine that will run the
+experiment.
 
 ## Quick Start
 
@@ -212,11 +188,8 @@ Current suite covers audio timing helpers, response/key state handling,
 backend behavior, psychophysics invariants, text layout/renderer basics, and
 other regression-prone utility paths.
 
-For CI/headless testing, use:
-
-```bash
-TACHYPY_AUDIO_BACKEND=dummy pytest
-```
+CI uses mocked TachyAudio streams for deterministic unit tests. Keep hardware
+audio-device validation as a dedicated local or lab-machine test.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Optional extras:
 ```bash
 pip install -e ".[test]"        # pytest
 pip install -e ".[text]"        # Pillow text fallback
-pip install -e ".[audio]"       # TachyAudio audio dependency
+# Audio support (tachyaudio) is included in the base install
 ```
 
 ### Audio dependency

--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -52,9 +52,15 @@ The retained ``backend`` argument accepts only ``None``, ``"auto"``, or
 Installation
 ------------
 
-The base TachyPy install depends on ``tachyaudio>=0.2.0b1``. Because tachyaudio
-is currently published as a beta release, use pre-release resolution when
-installing TachyPy from source if pip cannot resolve it automatically:
+The base TachyPy install depends on ``tachyaudio>=0.2.0b1``. In most cases, pip
+can resolve this dependency without enabling global pre-release selection:
+
+.. code-block:: bash
+
+   pip install tachypy
+
+If your resolver does not accept the tachyaudio pre-release automatically, retry
+with:
 
 .. code-block:: bash
 

--- a/docs/audio.rst
+++ b/docs/audio.rst
@@ -4,65 +4,70 @@ Audio
 Audio class
 -----------
 
-``Audio`` now uses a backend abstraction:
+``tachypy.Audio`` is now a convenience scheduler over ``tachyaudio``. TachyPy no
+longer owns sounddevice or dummy audio backends; low-level device handling,
+streaming, buffering, and latency statistics live in ``tachyaudio``.
 
-- ``sounddevice``: low-latency backend (recommended for timing-critical runs).
-- ``dummy``: no-op backend for CI/headless testing.
-- ``auto``: selects ``sounddevice`` when available, otherwise ``dummy``.
-
-Backend selection
------------------
-
-Select backend in code:
+Basic playback:
 
 .. code-block:: python
 
+   import numpy as np
    from tachypy import Audio
-   audio = Audio(sample_rate=44100, channels=1, backend="sounddevice")
 
-Or through environment:
+   audio = Audio(sample_rate=48000, channels=1)
+   tone = np.zeros(4800, dtype=np.float32)
+   audio.play(tone)
 
-.. code-block:: bash
+Scheduling
+----------
 
-   TACHYPY_AUDIO_BACKEND=dummy pytest
+``Audio.play(data, when=...)`` keeps the old TachyPy convenience API. ``when`` is
+an absolute monotonic time in seconds. Internally, TachyPy waits until that time
+and then writes the contiguous float32 frame buffer to ``tachyaudio.OutputStream``.
 
-CI guidance
------------
+.. code-block:: python
 
-Use the ``dummy`` backend in CI to avoid native audio-driver requirements.
-Keep hardware/audio integration tests in dedicated jobs or local validation
-passes.
+   import time
 
-Installing sounddevice prerequisites
-------------------------------------
+   audio = Audio(sample_rate=48000, channels=2, latency=0.01)
+   audio.play(stereo_buffer, when=time.monotonic() + 0.250)
 
-``sounddevice`` may require PortAudio system libraries.
+Configuration
+-------------
 
-Linux (Debian/Ubuntu):
+The following parameters are passed through to ``tachyaudio.OutputStream``:
 
-.. code-block:: bash
+- ``sample_rate``
+- ``channels``
+- ``block_size``
+- ``device_id``
+- ``latency``
+- ``timeout`` for write/drain operations
 
-   sudo apt update
-   sudo apt install libportaudio2 libportaudiocpp0 portaudio19-dev
+The retained ``backend`` argument accepts only ``None``, ``"auto"``, or
+``"tachyaudio"``. Legacy ``"sounddevice"`` and ``"dummy"`` values now raise a
+``ValueError``.
 
-macOS:
+Installation
+------------
 
-Install Homebrew (if needed):
-
-.. code-block:: bash
-
-   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-Then install PortAudio:
-
-.. code-block:: bash
-
-   brew install portaudio
-
-Windows:
-
-Pip wheels for ``sounddevice`` often work directly. If not, one workaround is:
+The base TachyPy install depends on ``tachyaudio>=0.2.0b1``. Because tachyaudio
+is currently published as a beta release, use pre-release resolution when
+installing TachyPy from source if pip cannot resolve it automatically:
 
 .. code-block:: bash
 
-   choco install portaudio
+   pip install --pre tachypy
+
+For direct development installs:
+
+.. code-block:: bash
+
+   pip install --pre -e .
+
+Testing
+-------
+
+Unit tests mock ``tachyaudio.OutputStream``. Hardware/audio-device validation
+should remain a dedicated local or lab-machine test, separate from CI.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ autosummary_generate = True
 autodoc_mock_imports = [
     "OpenGL",
     "glfw",
-    "sounddevice",
+    "tachyaudio",
     "screeninfo",
     "PIL",
     "freetype",

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -39,4 +39,3 @@ Notes
 -----
 
 - ``Screen`` defaults to GLFW, and ``Text`` defaults to the system-font renderer.
-- On constrained CI systems, set ``TACHYPY_AUDIO_BACKEND=dummy``.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -20,7 +20,7 @@ For development:
 
    git clone https://github.com/Charestlab/tachypy.git
    cd tachypy
-   pip install --pre -e .
+   pip install -e .
 
 Optional extras
 ---------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,11 +6,13 @@ Install TachyPy
 
 .. code-block:: bash
 
-   pip install tachypy
+   pip install --pre tachypy
 
 The base install includes GLFW for display/input, PyOpenGL, Pillow text
-support, and pyserial for serial trigger workflows. Pygame support has been
-removed; GLFW is the supported display/input backend.
+support, pyserial for serial trigger workflows, and TachyAudio for audio
+playback. Pygame support has been removed; GLFW is the supported display/input
+backend. TachyAudio is currently published as a beta release, so use
+``--pre`` when installing TachyPy from PyPI.
 
 For development:
 
@@ -18,7 +20,7 @@ For development:
 
    git clone https://github.com/Charestlab/tachypy.git
    cd tachypy
-   pip install -e .
+   pip install --pre -e .
 
 Optional extras
 ---------------
@@ -27,7 +29,7 @@ Optional extras
 
    pip install -e ".[test]"        # pytest, coverage, lint tooling
    pip install -e ".[text]"        # Pillow text fallback
-   pip install -e ".[audio_sd]"    # sounddevice backend
+   pip install -e ".[audio]"       # TachyAudio audio dependency
 
 Minimal loop
 ------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -11,8 +11,7 @@ Install TachyPy
 The base install includes GLFW for display/input, PyOpenGL, Pillow text
 support, pyserial for serial trigger workflows, and TachyAudio for audio
 playback. Pygame support has been removed; GLFW is the supported display/input
-backend. TachyAudio is currently published as a beta release, so use
-``--pre`` when installing TachyPy from PyPI.
+backend. TachyAudio is currently published as a beta release; if your pip resolver refuses pre-releases, pass ``--pre`` (or install tachyaudio explicitly).
 
 For development:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -29,7 +29,7 @@ Optional extras
 
    pip install -e ".[test]"        # pytest, coverage, lint tooling
    pip install -e ".[text]"        # Pillow text fallback
-   pip install -e ".[audio]"       # TachyAudio audio dependency
+   # Audio support (tachyaudio) is included in the base install
 
 Minimal loop
 ------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,7 +6,7 @@ Install TachyPy
 
 .. code-block:: bash
 
-   pip install --pre tachypy
+   pip install tachypy
 
 The base install includes GLFW for display/input, PyOpenGL, Pillow text
 support, pyserial for serial trigger workflows, and TachyAudio for audio

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -8,7 +8,7 @@ What is covered
 ---------------
 
 - Audio scheduling and channel-shape validation.
-- Audio backend selection and CI-safe dummy mode behavior.
+- TachyAudio-backed scheduling and channel-shape validation.
 - Response handling state transitions (key press/release behavior).
 - Draggable object movement and boundary clamping.
 - GLFW drag/input behavior.
@@ -42,4 +42,4 @@ Add new tests
 - Prefer pure logic tests over rendering integration tests where possible.
 - Mock GLFW/OpenGL interactions when asserting non-rendering behavior.
 - Add regression tests for every bug fix before release.
-- Use ``TACHYPY_AUDIO_BACKEND=dummy`` in CI and keep hardware tests separate.
+- Mock ``tachyaudio.OutputStream`` in CI and keep hardware audio tests separate.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyOpenGL>=3.1.0
 screeninfo>=0.6.0
 freetype-py>=2.4
 uharfbuzz>=0.39
+tachyaudio>=0.2.0b1

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ test =
 glfw =
     glfw>=2.7
 audio =
-    tachyaudio>=0.2.0b1
 text =
     Pillow>=10.0
 system_text =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tachypy
-version = 0.1.16
+version = 0.1.17
 author = Ian Charest and Frederic Gosselin
 author_email = charest.ian@gmail.com
 description = A package for psychophysics in Python, using GLFW and OpenGL.
@@ -10,12 +10,11 @@ url = https://github.com/CharestLab/tachypy
 license = MIT
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Operating System :: OS Independent
 
 [options]
@@ -31,7 +30,8 @@ install_requires =
     screeninfo>=0.6.0
     freetype-py>=2.4
     uharfbuzz>=0.39
-python_requires = >=3.6
+    tachyaudio>=0.2.0b1
+python_requires = >=3.10
 
 [options.packages.find]
 where = src
@@ -43,10 +43,8 @@ test =
     ruff>=0.6
 glfw =
     glfw>=2.7
-audio_sd =
-    sounddevice>=0.5
 audio =
-    sounddevice>=0.5
+    tachyaudio>=0.2.0b1
 text =
     Pillow>=10.0
 system_text =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tachypy
-version = 0.1.15
+version = 0.1.16
 author = Ian Charest and Frederic Gosselin
 author_email = charest.ian@gmail.com
 description = A package for psychophysics in Python, using GLFW and OpenGL.

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ with open('requirements.txt') as reqfile:
 
 setup(
     name='tachypy',
-    version='0.1.16',
+    version='0.1.17',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     install_requires=requires,
-    python_requires='>=3.6',
+    python_requires='>=3.10',
     author='Ian Charest and Frederic Gosselin',
     author_email='charest.ian@gmail.com',
     description='A package for timing-focused psychophysics using GLFW and OpenGL.',
@@ -22,12 +22,11 @@ setup(
     url='https://github.com/CharestLab/tachypy',
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Operating System :: OS Independent',
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as reqfile:
 
 setup(
     name='tachypy',
-    version='0.1.15',
+    version='0.1.16',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     install_requires=requires,

--- a/src/tachypy/audio.py
+++ b/src/tachypy/audio.py
@@ -86,7 +86,9 @@ class Audio:
         current_time = time.monotonic_ns()
         delay = int((float(when) * 1e9) - current_time)
         if delay < 0:
-            print("Warning: 'when' time is in the past. Playing immediately.")
+            import warnings
+
+            warnings.warn("'when' time is in the past; playing immediately.", RuntimeWarning, stacklevel=2)
             delay = 0
 
         thread = threading.Thread(target=self._playback_thread, args=(buffer, delay), daemon=True)

--- a/src/tachypy/audio.py
+++ b/src/tachypy/audio.py
@@ -140,7 +140,7 @@ class Audio:
                 with self._lock:
                     if self._stream is stream:
                         self._stream = None
-                    self.is_playing = False
+                        self.is_playing = False
 
     def _precise_delay(self, delay):
         """Wait for the specified nanosecond delay with high precision."""

--- a/src/tachypy/audio.py
+++ b/src/tachypy/audio.py
@@ -1,104 +1,36 @@
+"""TachyPy audio convenience wrapper backed by tachyaudio."""
+
+from __future__ import annotations
+
 import os
 import threading
 import time
-import warnings
 
 import numpy as np
 
 try:
-    import sounddevice as sd
-except Exception:
-    sd = None
-
-
-class _AudioBackend:
-    """Abstract audio backend interface used by :class:`Audio`."""
-
-    name = "abstract"
-
-    def play(self, data, sample_rate):
-        """Start playing a numpy buffer."""
-        raise NotImplementedError
-
-    def wait(self):
-        """Block until playback completes."""
-        raise NotImplementedError
-
-    def stop(self):
-        """Stop active playback."""
-        raise NotImplementedError
-
-    def close(self):
-        """Release backend resources."""
-        self.stop()
-
-
-class _SoundDeviceBackend(_AudioBackend):
-    """Sounddevice backend wrapping PortAudio."""
-
-    name = "sounddevice"
-
-    def play(self, data, sample_rate):
-        sd.play(data, samplerate=sample_rate)
-
-    def wait(self):
-        sd.wait()
-
-    def stop(self):
-        sd.stop()
-
-
-class _DummyBackend(_AudioBackend):
-    """No-op backend for CI/headless environments."""
-
-    name = "dummy"
-
-    def __init__(self):
-        self._play_until_ns = None
-
-    def play(self, data, sample_rate):
-        duration_ns = int((len(data) / float(sample_rate)) * 1e9)
-        self._play_until_ns = time.monotonic_ns() + max(duration_ns, 0)
-
-    def wait(self):
-        if self._play_until_ns is None:
-            return
-        remaining_ns = self._play_until_ns - time.monotonic_ns()
-        if remaining_ns > 0:
-            time.sleep(remaining_ns / 1e9)
-        self._play_until_ns = None
-
-    def stop(self):
-        self._play_until_ns = None
-
-
-def _build_backend(backend_name):
-    """Instantiate a backend from a backend selection string."""
-    if backend_name == "sounddevice":
-        if sd is None:
-            raise RuntimeError(
-                "Audio backend 'sounddevice' requested but sounddevice is unavailable. "
-                "Install with `pip install 'tachypy[audio_sd]'`."
-            )
-        return _SoundDeviceBackend()
-    if backend_name == "dummy":
-        return _DummyBackend()
-    if backend_name == "auto":
-        if sd is not None:
-            return _SoundDeviceBackend()
-        warnings.warn(
-            "sounddevice not available; falling back to dummy audio backend.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-        return _DummyBackend()
-    raise ValueError(f"Unsupported audio backend '{backend_name}'.")
+    import tachyaudio
+except Exception as err:  # pragma: no cover - exercised only in broken installs.
+    tachyaudio = None
+    _TACHYAUDIO_IMPORT_ERROR = err
+else:
+    _TACHYAUDIO_IMPORT_ERROR = None
 
 
 class Audio:
-    """Scheduled audio playback wrapper with pluggable backend support."""
+    """Schedule playback through :mod:`tachyaudio` while preserving TachyPy's API."""
 
-    def __init__(self, sample_rate=44100, channels=1, backend=None):
+    def __init__(
+        self,
+        sample_rate=44100,
+        channels=1,
+        backend=None,
+        *,
+        block_size=None,
+        device_id=None,
+        latency=None,
+        timeout=None,
+    ):
         """Initialize audio playback state.
 
         Parameters
@@ -106,31 +38,68 @@ class Audio:
         sample_rate : int
             Sample rate in Hz.
         channels : int
-            Number of audio output channels.
+            Number of output channels.
         backend : str | None
-            One of ``"auto"``, ``"sounddevice"``, ``"dummy"``.
-            ``None`` resolves from ``TACHYPY_AUDIO_BACKEND`` env var, then ``"auto"``.
+            Must be ``None``, ``"auto"``, or ``"tachyaudio"``. The argument is
+            retained for source compatibility; TachyPy no longer owns alternate
+            audio backends.
+        block_size, device_id, latency : optional
+            Passed through to ``tachyaudio.OutputStream``.
+        timeout : float | None
+            Timeout used for ``write_all`` and ``drain``.
         """
-        self.sample_rate = sample_rate
-        self.channels = channels
+        self.sample_rate = int(sample_rate)
+        self.channels = int(channels)
+        if self.sample_rate < 1:
+            raise ValueError("sample_rate must be positive")
+        if self.channels < 1:
+            raise ValueError("channels must be positive")
+
+        requested_backend = backend or os.getenv("TACHYPY_AUDIO_BACKEND", "tachyaudio")
+        if requested_backend == "auto":
+            requested_backend = "tachyaudio"
+        if requested_backend != "tachyaudio":
+            raise ValueError("TachyPy audio now supports only backend='tachyaudio'.")
+
+        if tachyaudio is None:
+            raise RuntimeError(
+                "tachyaudio is required for TachyPy audio. Install with `pip install tachyaudio`."
+            ) from _TACHYAUDIO_IMPORT_ERROR
+
+        self.backend_name = "tachyaudio"
+        self.block_size = block_size
+        self.device_id = device_id
+        self.latency = latency
+        self.timeout = timeout
         self.is_playing = False
-        requested_backend = backend or os.getenv("TACHYPY_AUDIO_BACKEND", "auto")
-        self.backend = _build_backend(requested_backend)
-        self.backend_name = self.backend.name
+        self._stream = None
+        self._lock = threading.Lock()
+        self._thread = None
 
     def play(self, data, when=0):
+        """Play a NumPy buffer, optionally scheduled at an absolute monotonic time.
+
+        ``when`` is expressed in seconds from ``time.monotonic_ns() / 1e9``.
+        The call starts a daemon thread and returns immediately.
         """
-        Plays a NumPy array as audio at a specified time.
-        :param data: NumPy array of audio data.
-        :param when: Absolute time in seconds (monotonic) when playback should start.
-        """
+        buffer = self._prepare_buffer(data)
+        current_time = time.monotonic_ns()
+        delay = int((float(when) * 1e9) - current_time)
+        if delay < 0:
+            print("Warning: 'when' time is in the past. Playing immediately.")
+            delay = 0
+
+        thread = threading.Thread(target=self._playback_thread, args=(buffer, delay), daemon=True)
+        self._thread = thread
+        thread.start()
+
+    def _prepare_buffer(self, data):
+        """Validate, channel-adapt, and return contiguous float32 audio frames."""
         if not isinstance(data, np.ndarray):
             raise ValueError("Data must be a NumPy array.")
 
-        # Ensure data has the correct shape
         if data.ndim == 1:
             if self.channels > 1:
-                # Duplicate mono data for multiple channels
                 data = np.tile(data[:, np.newaxis], (1, self.channels))
         elif data.ndim == 2:
             if data.shape[1] != self.channels:
@@ -138,63 +107,73 @@ class Audio:
         else:
             raise ValueError("Data must be a 1D or 2D NumPy array.")
 
-        # Ensure data is in float32 format
         if data.dtype != np.float32:
             data = data.astype(np.float32)
-
-        # Calculate delay until 'when' time
-        current_time = time.monotonic_ns()
-        delay = (when * 1e9) - current_time # convert delay from secs to nanosecs
-
-        if delay < 0:
-            print("Warning: 'when' time is in the past. Playing immediately.")
-            delay = 0
-
-        # Start playback in a separate thread to avoid blocking
-        threading.Thread(target=self._playback_thread, args=(data, delay), daemon=True).start()
+        return np.ascontiguousarray(data)
 
     def _playback_thread(self, data, delay):
         """Worker thread that waits for the target time then plays audio."""
         if delay > 0:
-            # High-precision wait until the scheduled time
             self._precise_delay(delay)
 
-        self.is_playing = True
-        self.backend.play(data, sample_rate=self.sample_rate)
-        self.backend.wait()
-        self.is_playing = False
+        stream = tachyaudio.OutputStream(
+            sample_rate=self.sample_rate,
+            channels=self.channels,
+            block_size=self.block_size,
+            device_id=self.device_id,
+            latency=self.latency,
+            dtype="float32",
+        )
+        with self._lock:
+            self._stream = stream
+            self.is_playing = True
+
+        try:
+            stream.start()
+            stream.write_all(data, timeout=self.timeout)
+            if not stream.drain(timeout=self.timeout):
+                raise TimeoutError("audio playback did not drain before timeout")
+        finally:
+            try:
+                stream.close()
+            finally:
+                with self._lock:
+                    if self._stream is stream:
+                        self._stream = None
+                    self.is_playing = False
 
     def _precise_delay(self, delay):
-        """Wait for the specified delay with high precision."""
-        end_time = time.monotonic_ns() + delay
+        """Wait for the specified nanosecond delay with high precision."""
+        end_time = time.monotonic_ns() + int(delay)
         while True:
             remaining = end_time - time.monotonic_ns()
             sleep_duration = self._sleep_duration_for_remaining_ns(remaining)
             if sleep_duration is None:
                 if remaining <= 0:
                     break
-                # Busy-wait for the final few milliseconds for precision.
                 continue
             time.sleep(sleep_duration)
 
     @staticmethod
     def _sleep_duration_for_remaining_ns(remaining_ns):
-        """
-        Return a sleep duration in seconds for a remaining nanosecond delay.
-        """
+        """Return a sleep duration in seconds for a remaining nanosecond delay."""
         if remaining_ns <= 0:
             return None
-        # Sleep while there is still more than ~10 ms left.
         if remaining_ns > 10_000_000:
             return 0.005
         return None
 
     def stop(self):
         """Stop current playback immediately."""
-        self.backend.stop()
-        self.is_playing = False
+        with self._lock:
+            stream = self._stream
+        if stream is not None:
+            stream.stop()
+            stream.close()
+        with self._lock:
+            self._stream = None
+            self.is_playing = False
 
     def close(self):
         """Close audio resources by stopping playback."""
         self.stop()
-        self.backend.close()

--- a/src/tachypy/audio.py
+++ b/src/tachypy/audio.py
@@ -171,8 +171,9 @@ class Audio:
             stream.stop()
             stream.close()
         with self._lock:
-            self._stream = None
-            self.is_playing = False
+            if self._stream is stream:
+                self._stream = None
+                self.is_playing = False
 
     def close(self):
         """Close audio resources by stopping playback."""

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -31,10 +31,9 @@ def test_play_expands_mono_data_to_requested_channels(monkeypatch):
     monkeypatch.setattr("tachypy.audio.threading.Thread", FakeThread)
     monkeypatch.setattr("tachypy.audio.time.monotonic_ns", lambda: 2_000_000_000)
 
-    audio = Audio(sample_rate=44_100, channels=2, backend="dummy")
+    audio = Audio(sample_rate=44_100, channels=2)
     mono = np.array([0.1, -0.1, 0.2], dtype=np.float64)
 
-    # when is in the past, delay should be clamped to zero.
     audio.play(mono, when=1.0)
 
     assert captured["shape"] == (3, 2)
@@ -43,7 +42,7 @@ def test_play_expands_mono_data_to_requested_channels(monkeypatch):
 
 
 def test_play_raises_for_wrong_channel_count():
-    audio = Audio(channels=2, backend="dummy")
+    audio = Audio(channels=2)
     stereo = np.array([[0.1], [0.2]], dtype=np.float32)
 
     with pytest.raises(ValueError, match="channels"):
@@ -51,11 +50,11 @@ def test_play_raises_for_wrong_channel_count():
 
 
 def test_invalid_backend_raises():
-    with pytest.raises(ValueError, match="Unsupported audio backend"):
-        Audio(backend="nope")
+    with pytest.raises(ValueError, match="tachyaudio"):
+        Audio(backend="sounddevice")
 
 
-def test_dummy_backend_selected_via_env(monkeypatch):
-    monkeypatch.setenv("TACHYPY_AUDIO_BACKEND", "dummy")
+def test_backend_env_accepts_auto(monkeypatch):
+    monkeypatch.setenv("TACHYPY_AUDIO_BACKEND", "auto")
     audio = Audio()
-    assert audio.backend_name == "dummy"
+    assert audio.backend_name == "tachyaudio"

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -1,16 +1,17 @@
 import pytest
 
 import tachypy.audio as audio_module
+from tachypy.audio import Audio
 
 
-def test_sounddevice_backend_request_errors_when_unavailable(monkeypatch):
-    monkeypatch.setattr(audio_module, "sd", None)
-    with pytest.raises(RuntimeError, match="sounddevice"):
-        audio_module._build_backend("sounddevice")
+def test_audio_requires_tachyaudio_when_missing(monkeypatch):
+    monkeypatch.setattr(audio_module, "tachyaudio", None)
+    monkeypatch.setattr(audio_module, "_TACHYAUDIO_IMPORT_ERROR", ImportError("missing"))
+
+    with pytest.raises(RuntimeError, match="tachyaudio is required"):
+        Audio()
 
 
-def test_auto_backend_falls_back_to_dummy_with_warning(monkeypatch):
-    monkeypatch.setattr(audio_module, "sd", None)
-    with pytest.warns(RuntimeWarning, match="falling back to dummy"):
-        backend = audio_module._build_backend("auto")
-    assert backend.name == "dummy"
+def test_legacy_dummy_backend_is_rejected():
+    with pytest.raises(ValueError, match="tachyaudio"):
+        Audio(backend="dummy")

--- a/tests/test_audio_extended.py
+++ b/tests/test_audio_extended.py
@@ -103,6 +103,36 @@ def test_stop_closes_active_stream(monkeypatch):
     assert audio.is_playing is False
 
 
+def test_stop_does_not_clear_replaced_stream(monkeypatch):
+    install_fake_tachyaudio(monkeypatch)
+    audio = Audio()
+    stream = FakeOutputStream(sample_rate=1, channels=1, block_size=None, device_id=None, latency=None, dtype="float32")
+    replacement = FakeOutputStream(
+        sample_rate=1,
+        channels=1,
+        block_size=None,
+        device_id=None,
+        latency=None,
+        dtype="float32",
+    )
+    audio._stream = stream
+    audio.is_playing = True
+
+    original_close = stream.close
+
+    def close_and_replace():
+        audio._stream = replacement
+        audio.is_playing = True
+        original_close()
+
+    stream.close = close_and_replace
+
+    audio.stop()
+
+    assert audio._stream is replacement
+    assert audio.is_playing is True
+
+
 def test_audio_constructor_validates_sample_rate_and_channels():
     with pytest.raises(ValueError, match="sample_rate"):
         Audio(sample_rate=0)

--- a/tests/test_audio_extended.py
+++ b/tests/test_audio_extended.py
@@ -88,6 +88,26 @@ def test_audio_playback_thread_delay_and_drain_timeout(monkeypatch):
     assert FakeOutputStream.calls[-1] == ("close",)
 
 
+def test_playback_thread_does_not_clear_replaced_stream(monkeypatch):
+    FakeOutputStream.calls = []
+    replacement = object()
+
+    class ReplacingOutputStream(FakeOutputStream):
+        def close(self):
+            audio._stream = replacement
+            audio.is_playing = True
+            super().close()
+
+    fake = type("FakeTachyAudio", (), {"OutputStream": ReplacingOutputStream})
+    monkeypatch.setattr(audio_module, "tachyaudio", fake)
+    audio = Audio()
+
+    audio._playback_thread(np.zeros(4, dtype=np.float32), delay=0)
+
+    assert audio._stream is replacement
+    assert audio.is_playing is True
+
+
 def test_stop_closes_active_stream(monkeypatch):
     install_fake_tachyaudio(monkeypatch)
     audio = Audio()

--- a/tests/test_audio_extended.py
+++ b/tests/test_audio_extended.py
@@ -2,102 +2,109 @@ import numpy as np
 import pytest
 
 import tachypy.audio as audio_module
-from tachypy.audio import Audio, _AudioBackend, _DummyBackend, _SoundDeviceBackend
+from tachypy.audio import Audio
 
 
-def test_audio_backend_base_methods_raise_and_close_calls_stop():
-    backend = _AudioBackend()
-    with pytest.raises(NotImplementedError):
-        backend.play(np.zeros(1, dtype=np.float32), 44100)
-    with pytest.raises(NotImplementedError):
-        backend.wait()
-    with pytest.raises(NotImplementedError):
-        backend.stop()
-
-
-def test_sounddevice_backend_calls_sd(monkeypatch):
+class FakeOutputStream:
     calls = []
+    drain_result = True
 
-    class FakeSD:
-        @staticmethod
-        def play(data, samplerate):
-            calls.append(("play", samplerate, data.shape))
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.closed = False
+        FakeOutputStream.calls.append(("init", kwargs))
 
-        @staticmethod
-        def wait():
-            calls.append(("wait",))
+    def start(self):
+        FakeOutputStream.calls.append(("start",))
 
-        @staticmethod
-        def stop():
-            calls.append(("stop",))
+    def write_all(self, data, timeout=None):
+        FakeOutputStream.calls.append(("write_all", data.shape, data.dtype, timeout))
+        return data.shape[0]
 
-    monkeypatch.setattr(audio_module, "sd", FakeSD)
-    backend = _SoundDeviceBackend()
-    backend.play(np.zeros((4, 1), dtype=np.float32), sample_rate=22050)
-    backend.wait()
-    backend.stop()
-    assert calls == [("play", 22050, (4, 1)), ("wait",), ("stop",)]
+    def drain(self, timeout=None):
+        FakeOutputStream.calls.append(("drain", timeout))
+        return self.drain_result
 
+    def stop(self):
+        FakeOutputStream.calls.append(("stop",))
 
-def test_dummy_backend_wait_noop_and_sleep_branch(monkeypatch):
-    backend = _DummyBackend()
-    backend.wait()  # no scheduled playback branch
-
-    t = {"now": 1_000_000_000}
-    slept = []
-
-    monkeypatch.setattr(audio_module.time, "monotonic_ns", lambda: t["now"])
-    monkeypatch.setattr(audio_module.time, "sleep", lambda s: slept.append(s))
-    backend.play(np.zeros(100, dtype=np.float32), sample_rate=100)
-    backend.wait()
-    assert slept and slept[0] > 0
+    def close(self):
+        self.closed = True
+        FakeOutputStream.calls.append(("close",))
 
 
-def test_build_backend_auto_prefers_sounddevice_when_available(monkeypatch):
-    class FakeSD:
-        pass
-
-    monkeypatch.setattr(audio_module, "sd", FakeSD)
-    backend = audio_module._build_backend("auto")
-    assert backend.name == "sounddevice"
+def install_fake_tachyaudio(monkeypatch):
+    FakeOutputStream.calls = []
+    fake = type("FakeTachyAudio", (), {"OutputStream": FakeOutputStream})
+    monkeypatch.setattr(audio_module, "tachyaudio", fake)
+    return fake
 
 
 def test_audio_play_validation_errors():
-    audio = Audio(backend="dummy")
+    audio = Audio()
     with pytest.raises(ValueError, match="NumPy"):
         audio.play([1, 2, 3], when=0)
     with pytest.raises(ValueError, match="1D or 2D"):
         audio.play(np.zeros((2, 2, 2), dtype=np.float32), when=0)
 
 
-def test_audio_playback_thread_and_close(monkeypatch):
-    events = []
+def test_audio_playback_thread_uses_tachyaudio_stream(monkeypatch):
+    install_fake_tachyaudio(monkeypatch)
+    audio = Audio(sample_rate=22_050, channels=1, block_size=64, device_id="dev", latency=0.01, timeout=0.5)
+    data = np.zeros(8, dtype=np.float32)
 
-    class FakeBackend:
-        name = "fake"
+    audio._playback_thread(data, delay=0)
 
-        def play(self, data, sample_rate):
-            events.append(("play", sample_rate, data.shape))
-
-        def wait(self):
-            events.append(("wait",))
-
-        def stop(self):
-            events.append(("stop",))
-
-        def close(self):
-            events.append(("close",))
-
-    monkeypatch.setattr(audio_module, "_build_backend", lambda _: FakeBackend())
-    audio = Audio(backend="dummy")
-    audio._playback_thread(np.zeros(8, dtype=np.float32), delay=0)
     assert audio.is_playing is False
-    assert events[:2] == [("play", 44100, (8,)), ("wait",)]
+    assert FakeOutputStream.calls[0] == (
+        "init",
+        {
+            "sample_rate": 22_050,
+            "channels": 1,
+            "block_size": 64,
+            "device_id": "dev",
+            "latency": 0.01,
+            "dtype": "float32",
+        },
+    )
+    assert ("start",) in FakeOutputStream.calls
+    assert ("write_all", (8,), np.dtype("float32"), 0.5) in FakeOutputStream.calls
+    assert ("drain", 0.5) in FakeOutputStream.calls
+    assert FakeOutputStream.calls[-1] == ("close",)
 
+
+def test_audio_playback_thread_delay_and_drain_timeout(monkeypatch):
+    install_fake_tachyaudio(monkeypatch)
+    audio = Audio(timeout=0.1)
+    events = []
     monkeypatch.setattr(audio, "_precise_delay", lambda d: events.append(("delay", d)))
-    audio._playback_thread(np.zeros(4, dtype=np.float32), delay=10)
-    assert ("delay", 10) in events
+    FakeOutputStream.drain_result = False
+
+    with pytest.raises(TimeoutError, match="did not drain"):
+        audio._playback_thread(np.zeros(4, dtype=np.float32), delay=10)
+
+    FakeOutputStream.drain_result = True
+    assert events == [("delay", 10)]
+    assert FakeOutputStream.calls[-1] == ("close",)
+
+
+def test_stop_closes_active_stream(monkeypatch):
+    install_fake_tachyaudio(monkeypatch)
+    audio = Audio()
+    stream = FakeOutputStream(sample_rate=1, channels=1, block_size=None, device_id=None, latency=None, dtype="float32")
+    audio._stream = stream
+    audio.is_playing = True
 
     audio.stop()
-    audio.close()
-    assert ("stop",) in events and ("close",) in events
+
+    assert ("stop",) in FakeOutputStream.calls
+    assert ("close",) in FakeOutputStream.calls
+    assert audio._stream is None
+    assert audio.is_playing is False
+
+
+def test_audio_constructor_validates_sample_rate_and_channels():
+    with pytest.raises(ValueError, match="sample_rate"):
+        Audio(sample_rate=0)
+    with pytest.raises(ValueError, match="channels"):
+        Audio(channels=0)


### PR DESCRIPTION
## Summary
- Replace TachyPy-owned sounddevice/dummy audio backends with a thin `tachyaudio.OutputStream` wrapper
- Add `tachyaudio>=0.2.0b1` as the base audio dependency and remove `sounddevice` extras/docs
- Raise TachyPy's Python requirement to `>=3.10` to match TachyAudio
- Update audio tests to mock TachyAudio streams instead of sounddevice/dummy backends
- Bump package metadata to `0.1.17` because `0.1.16` is already published

## Validation
- `./.venv/bin/pytest --cov=tachypy --cov-report=term-missing --cov-fail-under=80` -> 82 passed, 92.04% coverage
- `./.venv/bin/ruff check src tests` -> passed
- `./.venv/bin/python -m sphinx -b html docs /tmp/tachypy-docs-build` -> passed
- `./.venv/bin/python -m pip check` -> no broken requirements
- Temporary venv install resolved `tachyaudio==0.2.0b1` from PyPI and imported `tachypy.Audio` successfully